### PR TITLE
ES-22 Lustre libvirt driver failed to attach volume: no such option qemu_allowed_storage_drivers in group

### DIFF
--- a/nova/virt/libvirt/volume/lustre.py
+++ b/nova/virt/libvirt/volume/lustre.py
@@ -36,37 +36,19 @@ class LibvirtLustreVolumeDriver(fs.LibvirtBaseFileSystemVolumeDriver):
         """Returns xml for libvirt."""
         conf = super(LibvirtLustreVolumeDriver,
                      self).get_config(connection_info, disk_info)
-
         data = connection_info['data']
-
-        if 'lustre' in CONF.libvirt.qemu_allowed_storage_drivers:
-            vol_name = data['export'].split('/')[1]
-            source_host = data['export'].split('/')[0][:-1]
-
-            conf.source_ports = ['24007']
-            conf.source_type = 'network'
-            conf.source_protocol = 'lustre'
-            conf.source_hosts = [source_host]
-            conf.source_name = '%s/%s' % (vol_name, data['name'])
-        else:
-            conf.source_type = 'file'
-            conf.source_path = connection_info['data']['device_path']
-
-        conf.driver_format = connection_info['data'].get('format', 'raw')
-
+        conf.source_type = 'file'
+        conf.source_path = data['device_path']
+        conf.driver_format = data.get('format', 'raw')
         return conf
 
     def connect_volume(self, connection_info, instance):
-        if 'lustre' not in CONF.libvirt.qemu_allowed_storage_drivers:
-            self._ensure_mounted(connection_info)
-            connection_info['data']['device_path'] = \
-                self._get_device_path(connection_info)
+        self._ensure_mounted(connection_info)
+        connection_info['data']['device_path'] = \
+            self._get_device_path(connection_info)
 
     def disconnect_volume(self, connection_info, disk_dev, instance):
         """Disconnect the volume."""
-
-        if 'lustre' in CONF.libvirt.qemu_allowed_storage_drivers:
-            return
 
         mount_path = self._get_mount_path(connection_info)
 


### PR DESCRIPTION
**ES-22 Lustre libvirt driver failed to attach volume: no such option qemu_allowed_storage_drivers in group**